### PR TITLE
Fix device of attention_mask

### DIFF
--- a/modeling_mpt.py
+++ b/modeling_mpt.py
@@ -159,8 +159,12 @@ class MPTModel(MPTPreTrainedModel):
         if attention_mask is not None:
             attention_mask = attention_mask.bool()
         else:
+            if input_ids is not None:
+                device = input_ids.device
+            else:
+                device = inputs_embeds.device
             attention_mask = torch.ones(
-                (batch_size, seq_length_with_past), dtype=torch.bool, device=inputs_embeds.device
+                (batch_size, seq_length_with_past), dtype=torch.bool, device=device
             )
 
         if inputs_embeds is None:


### PR DESCRIPTION
Thank you for sharing valuable code.

This pull request addresses the issue with the device argument in the modeling_mpt.py file.  
Specifically, when `input_ids` is not `None` and `input_embeds` is `None`, an error occurs with the `attention_mask` because `torch.ones` refers to the device of `input_embeds`, which is None.  
To resolve this, the pull request introduces a condition to select the appropriate device.

If this repository does not accept contributions from others, I understand if you decide to close this pull request.
